### PR TITLE
chore: create docker setup folder for localhost yorkie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # collab-dotting
 
 "collab-dotting" is an editor that enables collaborative creation of pixel art using dotting.
+
+## Initial Setup for Collaborative Editing using yorkie
+
+### Enable collaborative editing locally with Envoy, Yorkie and MongoDB with docker
+
+You must have docker installed in your machine beforehand.
+
+[Install Docker](https://docs.docker.com/engine/install/) if you don't have it yet.
+
+After installing docker, you must enable docker daemon in your machine. Open the Docker Desktop you've installed.
+
+After the daemon is running, you can run the following command to check if docker is running properly.
+
+```bash
+$ docker ps -a
+```
+
+Start MongoDB, Yorkie and Envoy proxy in a terminal session (You only need to run this once)
+
+```bash
+$ docker-compose -f docker/docker-compose.yml up --build -d
+```
+
+Afterwards, whenever you want to test dotting with collaborative editing, just simply open docker daemon and you are good to go.

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,0 +1,32 @@
+version: '3.3'
+
+services:
+  envoy:
+    build:
+      context: ./
+      dockerfile: ./envoy.Dockerfile
+    image: 'grpcweb:envoy'
+    container_name: 'envoy'
+    restart: always
+    ports:
+      - '8080:8080'
+      - '9901:9901'
+    command: ['/etc/envoy/envoy-ci.yaml']
+    depends_on:
+      - yorkie
+  yorkie:
+    image: 'yorkieteam/yorkie:latest'
+    container_name: 'yorkie'
+    command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
+    restart: always
+    ports:
+      - '11101:11101'
+      - '11102:11102'
+    depends_on:
+      - mongo
+  mongo:
+    image: 'mongo:latest'
+    container_name: 'mongo'
+    restart: always
+    ports:
+      - '27017:27017'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.3'
+
+services:
+  envoy:
+    build:
+      context: ./
+      dockerfile: ./envoy.Dockerfile
+    image: 'grpcweb:envoy'
+    container_name: 'envoy'
+    restart: always
+    ports:
+      - '8080:8080'
+      - '9901:9901'
+    command: ['/etc/envoy/envoy.yaml']
+    depends_on:
+      - yorkie
+    # If you're using Mac or Windows, this special domain name("host.docker.internal" which makes containers able to connect to the host)
+    # is supported by default.
+    # But if you're using Linux and want an envoy container to communicate with the host,
+    # it may help to define "host.docker.internal" in extra_hosts.
+    # (Actually, other hostnames are available, but in that case you should update clusters[].host configurations of envoy.yaml)
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+  yorkie:
+    image: 'yorkieteam/yorkie:latest'
+    container_name: 'yorkie'
+    command: ['server', '--enable-pprof']
+    restart: always
+    ports:
+      - '11101:11101'
+      - '11102:11102'

--- a/docker/envoy-ci.yaml
+++ b/docker/envoy-ci.yaml
@@ -1,0 +1,54 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: yorkie_rpc_listener
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 8080 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route:
+                  cluster: yorkie_rpc_service
+                  # https://github.com/grpc/grpc-web/issues/361
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
+              cors:
+                allow_origin_string_match:
+                - prefix: "*"
+                allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-api-key,x-shard-key,x-user-agent,x-grpc-web,grpc-timeout,authorization,x-yorkie-user-agent
+                max_age: "1728000"
+                expose_headers: custom-header-1,grpc-status,grpc-message
+          http_filters:
+          - name: envoy.filters.http.grpc_web
+          - name: envoy.filters.http.cors
+          - name: envoy.filters.http.router
+  clusters:
+  - name: yorkie_rpc_service
+    connect_timeout: 0.25s
+    type: logical_dns
+    http2_protocol_options: {}
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: yorkie_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: yorkie
+                    port_value: 11101

--- a/docker/envoy.Dockerfile
+++ b/docker/envoy.Dockerfile
@@ -1,0 +1,8 @@
+FROM envoyproxy/envoy:v1.19.0
+
+COPY ./envoy.yaml /etc/envoy/envoy.yaml
+COPY ./envoy-ci.yaml /etc/envoy/envoy-ci.yaml
+
+ENTRYPOINT ["/usr/local/bin/envoy", "-c"]
+
+CMD /etc/envoy/envoy.yaml

--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -1,0 +1,59 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: yorkie_rpc_listener
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 8080 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route:
+                  cluster: yorkie_rpc_service
+                  # https://github.com/grpc/grpc-web/issues/361
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
+              cors:
+                allow_origin_string_match:
+                - prefix: "*"
+                allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-api-key,x-shard-key,x-user-agent,x-grpc-web,grpc-timeout,authorization,x-yorkie-user-agent
+                max_age: "1728000"
+                expose_headers: custom-header-1,grpc-status,grpc-message
+          http_filters:
+          - name: envoy.filters.http.grpc_web
+          - name: envoy.filters.http.cors
+          - name: envoy.filters.http.router
+  clusters:
+  - name: yorkie_rpc_service
+    connect_timeout: 0.25s
+    type: logical_dns
+    http2_protocol_options: {}
+    lb_policy: round_robin
+    # Input the address which envoy can connect to as a yorkie server.
+    # When you want envoy container to communicate with your host machine, you should set as the following
+    # - Windows/Mac: Input host.docker.internal
+    # - Linux: an IP address of the host machine or docker-0 interface or some addresses defined in extra hosts of docker-compose.yml
+    # you can simply use the yorkie container name(e.g. yorkie) in docker-compose whatever your OS is.
+    load_assignment:
+      cluster_name: yorkie_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: host.docker.internal
+                port_value: 11101


### PR DESCRIPTION
For testing collaborative editing in localhost, one should setup docker for yorkie. I have added necessary docker files brought from yorkie-js-sdk to enable collaborative editing in localhost. One should run the docker command to setup the collaborative server.