### PR TITLE
feat: implement delete and set operation for grids

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "anonymous-animals-gen": "^1.0.3",
-    "dotting": "^2.0.5",
+    "dotting": "^2.0.6",
     "flowbite": "^1.8.1",
     "flowbite-react": "^0.5.0",
     "gh-pages": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,10 +2150,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dotting@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/dotting/-/dotting-2.0.5.tgz#bb67fed06b06b3f48601cc79adca316a6dfc5ab7"
-  integrity sha512-J2Fve0jBANCOEx8au+1mXS+qhu6BQKGGIYQg50g3Z7aNa1gW2SxiqXxdt3x+7KLi2Oeyfg3Ey1RXO+lU8UKteA==
+dotting@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/dotting/-/dotting-2.0.6.tgz#c1e382e6481008f414a4bb2a62ac775236b0f2ff"
+  integrity sha512-k+hjSo/i+9lmRlcM2h3PP84ci101avAXNUMrZwgNT2IgZQwUlUZgcKClLQ/fmrqwp1IL2tHxU5dWhvEIISTJ+g==
 
 easy-bem@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Enabled delete and set operations for grid change without any reliance on additional `addedOrDeletedRows` or `addedOrDeletedColumns`. The key is to check the operation `type`. While changing the columns and rows of the canvas, there seems to be some error in dotting. Maybe we should take a look into it. I believe the problem has to do with deleting an already deleted column or row.